### PR TITLE
Release v0.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.17] - 2026-02-02
+
+### Documentation
+
+- **Homebrew Formula Workflow Alignment**: Aligned CONTRIBUTING.md with CLAUDE.md automation strategy (#37)
+  - Prioritized automated `just release folder2md4llms` workflow as recommended method
+  - Fixed hardcoded version placeholder (`VERSION=0.5.17` → `VERSION=X.Y.Z`)
+  - Updated path references to use relative paths (`../homebrew-formulas`)
+  - Added automation context with `just` utility commands reference
+  - Consistent with rxiv-maker ecosystem patterns
+
 ## [0.5.16] - 2025-12-17
 
 ### Changed

--- a/src/folder2md4llms/__version__.py
+++ b/src/folder2md4llms/__version__.py
@@ -4,5 +4,5 @@ This file is the single source of truth for version information.
 Do not create __about__.py - use only this __version__.py file.
 """
 
-__version__ = "0.5.16"
-__version_tuple__ = (0, 5, 16)
+__version__ = "0.5.17"
+__version_tuple__ = (0, 5, 17)


### PR DESCRIPTION
Release v0.5.17: Documentation alignment

Documentation (#37):
- Homebrew formula workflow aligned with CLAUDE.md automation
- Automated `just release` workflow prioritized
- Consistent with rxiv-maker ecosystem

Changes:
- Bump version: 0.5.16 → 0.5.17
- Update CHANGELOG.md

Tag v0.5.17 pushed. Merging triggers PyPI publication.